### PR TITLE
Remove "Latest version" text from buttons on download page

### DIFF
--- a/src/pages/download.astro
+++ b/src/pages/download.astro
@@ -13,36 +13,36 @@ import Button from "../components/Button.astro";
     <div id="latest-version-native" style="display: none;"></div>
     <div class="flex flex-row flex-wrap gap-2">
       <Button
-        title="Latest Version (Linux, x86_64)"
+        title="Linux (x86_64)"
         href="https://maven.ornithemc.net/api/maven/latest/file/releases/net/ornithemc/ornithe-installer-rs/linux-x86_64?extension=bin"
       />
       <Button
-        title="Latest Version (Windows, x86_64)"
+        title="Windows (x86_64)"
         href="https://maven.ornithemc.net/api/maven/latest/file/releases/net/ornithemc/ornithe-installer-rs/windows-x86_64?extension=exe"
       />
       <Button
-        title="Latest Version (MacOS, universal)"
+        title="MacOS (universal)"
         href="https://maven.ornithemc.net/api/maven/latest/file/releases/net/ornithemc/ornithe-installer-rs/macos-universal2?extension=bin"
       />
       <br />
       <Button
-        title="Latest Version (Linux, aarch64)"
+        title="Linux (aarch64)"
         href="https://maven.ornithemc.net/api/maven/latest/file/releases/net/ornithemc/ornithe-installer-rs/linux-aarch64?extension=bin"
       />
       <Button
-        title="Latest Version (Windows, x86)"
+        title="Windows (x86)"
         href="https://maven.ornithemc.net/api/maven/latest/file/releases/net/ornithemc/ornithe-installer-rs/windows-x86?extension=exe"
       />
       <Button
-        title="Latest Version (Windows, aarch64)"
+        title="Windows (aarch64)"
         href="https://maven.ornithemc.net/api/maven/latest/file/releases/net/ornithemc/ornithe-installer-rs/windows-aarch64?extension=exe"
       />
       <Button
-        title="Latest Version (MacOS, x86_64)"
+        title="MacOS (x86_64)"
         href="https://maven.ornithemc.net/api/maven/latest/file/releases/net/ornithemc/ornithe-installer-rs/macos-x86_64?extension=bin"
       />
       <Button
-        title="Latest Version (MacOS, aarch64)"
+        title="MacOS (aarch64)"
         href="https://maven.ornithemc.net/api/maven/latest/file/releases/net/ornithemc/ornithe-installer-rs/macos-aarch64?extension=bin"
       />
       <span class="italic">
@@ -58,36 +58,36 @@ import Button from "../components/Button.astro";
       </span>
       <div class="flex flex-row flex-wrap gap-2">
         <Button
-          title="Latest Version (Linux, x86_64)"
+          title="Linux (x86_64)"
           href="https://maven.ornithemc.net/api/maven/latest/file/releases/net/ornithemc/ornithe-installer-rs/linux-x86_64?extension=bin&classifier=cli"
         />
         <Button
-          title="Latest Version (Windows, x86_64)"
+          title="Windows (x86_64)"
           href="https://maven.ornithemc.net/api/maven/latest/file/releases/net/ornithemc/ornithe-installer-rs/windows-x86_64?extension=exe&classifier=cli"
         />
         <Button
-          title="Latest Version (MacOS, universal)"
+          title="MacOS (universal)"
           href="https://maven.ornithemc.net/api/maven/latest/file/releases/net/ornithemc/ornithe-installer-rs/macos-universal2?extension=bin&classifier=cli"
         />
         <br />
         <Button
-          title="Latest Version (Linux, aarch64)"
+          title="Linux (aarch64)"
           href="https://maven.ornithemc.net/api/maven/latest/file/releases/net/ornithemc/ornithe-installer-rs/linux-aarch64?extension=bin&classifier=cli"
         />
         <Button
-          title="Latest Version (Windows, x86)"
+          title="Windows (x86)"
           href="https://maven.ornithemc.net/api/maven/latest/file/releases/net/ornithemc/ornithe-installer-rs/windows-x86?extension=exe&classifier=cli"
         />
         <Button
-          title="Latest Version (Windows, aarch64)"
+          title="Windows (aarch64)"
           href="https://maven.ornithemc.net/api/maven/latest/file/releases/net/ornithemc/ornithe-installer-rs/windows-aarch64?extension=exe&classifier=cli"
         />
         <Button
-          title="Latest Version (MacOS, x86_64)"
+          title="MacOS (x86_64)"
           href="https://maven.ornithemc.net/api/maven/latest/file/releases/net/ornithemc/ornithe-installer-rs/macos-x86_64?extension=bin&classifier=cli"
         />
         <Button
-          title="Latest Version (MacOS, aarch64)"
+          title="MacOS (aarch64)"
           href="https://maven.ornithemc.net/api/maven/latest/file/releases/net/ornithemc/ornithe-installer-rs/macos-aarch64?extension=bin&classifier=cli"
         />
       </div>
@@ -96,11 +96,11 @@ import Button from "../components/Button.astro";
     <div id="latest-version-jar" style="display: none;"></div>
     <div class="flex flex-row flex-wrap gap-2">
       <Button
-        title="Latest Version (JAR)"
+        title="Universal (JAR)"
         href="https://maven.ornithemc.net/api/maven/latest/file/releases/net/ornithemc/ornithe-installer"
       />
       <Button
-        title="Latest Version (EXE)"
+        title="Windows (EXE)"
         href="https://maven.ornithemc.net/api/maven/latest/file/releases/net/ornithemc/ornithe-installer-native-bootstrap/windows-x86_64?extension=exe"
       />
     </div>


### PR DESCRIPTION
There are no older downloads on that page, and the heading above the buttons already say it's the latest version. 