### PR TITLE
Fix mod json dependency specifier generation for snapshots

### DIFF
--- a/public/minecraft_semver.js
+++ b/public/minecraft_semver.js
@@ -186,7 +186,7 @@ function normalizeVersion(name, release) {
             }
         }
     } else if ((matches = name.match(SNAPSHOT_PATTERN)) != null) {
-        name = "alpha." + matches[1] + matches[2] + matches[3];
+        name = "alpha." + matches[1] + "." + matches[2] + "." + matches[3];
     } else {
         // Try short-circuiting special versions which are complete on their own
         let ret = normalizeSpecialVersion(name);


### PR DESCRIPTION
Fixes the mod json dependency specifiers on the develop page being incorrect for snapshots.

```diff
- "minecraft": "1.8-alpha.148a"
+ "minecraft": "1.8-alpha.14.8.a"
```