### PR TITLE
(Installer) Use no file extensions for *nix platforms

### DIFF
--- a/public/installer.js
+++ b/public/installer.js
@@ -74,7 +74,7 @@
         if (platform.startsWith("windows")) {
             return "exe"
         }
-        return "bin"
+        return ""
     }
 
 })()

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,7 +16,7 @@ import Button from "../components/Button.astro";
       <div id="latest-version-native" style="display: none;"></div>
       <div id="web-installer" style="display: none;"></div>
       <div id="platform-download" style="display: none;"></div>
-      <a href="/download">View all downloads</a>
+      <a href="/download" class="w-fit">View all downloads</a>
     </div>
     <div id="about-us" class="main-section">
       <h1>About Us</h1>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,19 +19,21 @@ import Button from "../components/Button.astro";
       <a href="/download">View all downloads</a>
     </div>
     <div id="about-us" class="main-section">
-      <h1>About Us</h2>
+      <h1>About Us</h1>
       <p>
-        The Ornithe Project enables the use of the <b>Fabric</b> and <b>Quilt</b> mod
-        loaders on old Minecraft versions, from the earliest versions of the
-        <b>pre-classic</b> era up to release <b>1.14.4</b>. We aim to support all
-        possible versions within this range, even as once-lost versions are found and
-        archived.
+        The Ornithe Project enables the use of the <b>Fabric</b> and <b>Quilt</b
+        > mod loaders on old Minecraft versions, from the earliest versions of the
+        <b>pre-classic</b> era up to release <b>1.14.4</b>. We aim to support
+        all possible versions within this range, even as once-lost versions are
+        found and archived.
       </p>
       <p>
-        Ornithe offers <b>high-quality mappings</b> and a <b>light-weight library of
-        APIs</b>, ensuring a consistent modding experience across the range of
-        supported Minecraft versions. We also offer more obscure <b>Java bytecode
-        patches</b> to clean up even heavily obfuscated versions.
+        Ornithe offers <b>high-quality mappings</b> and a <b
+          >light-weight library of APIs</b
+        >, ensuring a consistent modding experience across the range of
+        supported Minecraft versions. We also offer more obscure <b
+          >Java bytecode patches</b
+        > to clean up even heavily obfuscated versions.
       </p>
     </div>
     <div id="libraries" class="main-section">
@@ -44,10 +46,8 @@ import Button from "../components/Button.astro";
             modding with Ornithe.
           </span>
         </div>
-        <div class="tile empty-tile">
-        </div>
-        <div class="tile empty-tile">
-        </div>
+        <div class="tile empty-tile"></div>
+        <div class="tile empty-tile"></div>
       </div>
     </div>
     <div id="toolchain" class="main-section">
@@ -57,14 +57,15 @@ import Button from "../components/Button.astro";
         <div class="tile magenta-tile">
           <h3>Feather</h3>
           <span>
-            A set of mappings that provides a consistent modding experience across
-            a wide range of Minecraft versions.
+            A set of mappings that provides a consistent modding experience
+            across a wide range of Minecraft versions.
           </span>
         </div>
         <div class="tile fuchsia-tile">
           <h3>Calamus</h3>
           <span>
-            An intermediate mapping layer that enables cross-version mod compatibility.
+            An intermediate mapping layer that enables cross-version mod
+            compatibility.
           </span>
         </div>
         <div class="tile red-tile">
@@ -91,7 +92,8 @@ import Button from "../components/Button.astro";
         <div class="tile yellow-tile">
           <h3>Raven</h3>
           <span>
-            Patches for throws clauses in method declarations in Java class files.
+            Patches for throws clauses in method declarations in Java class
+            files.
           </span>
         </div>
       </div>
@@ -111,16 +113,15 @@ import Button from "../components/Button.astro";
         <div class="tile cyan-tile">
           <h3>Exceptor</h3>
           <span>
-            A tool that patches throws clauses in method declarations in Java class files.
+            A tool that patches throws clauses in method declarations in Java
+            class files.
           </span>
         </div>
       </div>
       <div class="row">
         <div class="tile light-blue-tile">
           <h3>Condor</h3>
-          <span>
-            A local variable table generator for Java class files.
-          </span>
+          <span> A local variable table generator for Java class files. </span>
         </div>
         <div class="tile dark-blue-tile">
           <h3>Preen</h3>
@@ -128,17 +129,15 @@ import Button from "../components/Button.astro";
             Miscellaneous de-obfuscation patches for Java class files.
           </span>
         </div>
-        <div class="tile empty-tile">
-        </div>
+        <div class="tile empty-tile"></div>
       </div>
     </div>
-    <div>
-    </div>
-    <div>
-    </div>
+    <div></div>
+    <div></div>
     <div>
       <small>
-        NOT AN OFFICIAL MINECRAFT PRODUCT. NOT APPROVED BY OR ASSOCIATED WITH MOJANG OR MICROSOFT.
+        NOT AN OFFICIAL MINECRAFT PRODUCT. NOT APPROVED BY OR ASSOCIATED WITH
+        MOJANG OR MICROSOFT.
       </small>
     </div>
   </main>


### PR DESCRIPTION
This is currently supported in snapshot versions of reposilite, we may wait until a release.

The other commits are only semi-related but may be cherry-picked if desired, I have tried to keep them separate. Another question: do we want to have the buttons on the index page in one row or keep them below each other?